### PR TITLE
US70153: page loading fade-in behaviour

### DIFF
--- a/navigation-resolved.html
+++ b/navigation-resolved.html
@@ -1,0 +1,43 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="centerer.html">
+<link rel="import" href="items.html">
+<link rel="import" href="logo.html">
+<dom-module id="d2l-navigation-resolved">
+	<style>
+		:host {
+			display: block;
+		}
+		nav {
+			border-bottom: 1px solid #e6eaf0;
+		}
+		hr {
+			border-bottom: none;
+			border-top: 1px solid #e6eaf0;
+			margin: 0;
+		}
+	</style>
+	<template>
+		<nav>
+			<d2l-navigation-centerer>
+				<d2l-navigation-logo data="[[logo]]"></d2l-navigation-logo>
+			</d2l-navigation-centerer>
+			<hr />
+			<d2l-navigation-centerer>
+				<d2l-navigation-items items="[[items]]"></d2l-navigation-items>
+			</d2l-navigation-centerer>
+		</nav>
+	</template>
+</dom-module>
+<script>
+	Polymer({
+		is: 'd2l-navigation-resolved',
+		properties: {
+			items: {
+				type: Array
+			},
+			logo: {
+				type: Object
+			}
+		}
+	});
+</script>

--- a/navigation.html
+++ b/navigation.html
@@ -1,12 +1,8 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-ajax/iron-ajax.html">
-<link rel="import" href="centerer.html">
 <link rel="import" href="page-load-progress.html">
-<link rel="import" href="items.html">
-<link rel="import" href="logo.html">
-
+<link rel="import" href="navigation-resolved.html">
 <dom-module id="d2l-navigation">
-
 	<style>
 		:host {
 			background-color: #fff;
@@ -14,21 +10,13 @@
 			line-height: 1;
 			position: relative;
 		}
-		:host > nav {
-			border-bottom: 1px solid #e6eaf0;
-			opacity: 0;
+		d2l-navigation-resolved {
 			transition: opacity 200ms;
 		}
-		:host[loaded] > nav {
-			opacity: 1;
-		}
-		hr {
-			border-bottom: none;
-			border-top: 1px solid #e6eaf0;
-			margin: 0;
+		:host([loading]) d2l-navigation-resolved {
+			opacity: 0;
 		}
 	</style>
-
 	<template>
 		<iron-ajax
 			url="{{endpoint}}"
@@ -37,21 +25,12 @@
 			on-response="handleResponse"></iron-ajax>
 		<d2l-navigation-page-load-progress
 			color="[[response.properties.color]]"></d2l-navigation-page-load-progress>
-		<nav>
-			<d2l-navigation-centerer>
-				<d2l-navigation-logo data="[[logo]]"></d2l-navigation-logo>
-			</d2l-navigation-centerer>
-			<hr />
-			<d2l-navigation-centerer>
-				<d2l-navigation-items items="[[items]]"></d2l-navigation-items>
-			</d2l-navigation-centerer>
-		</nav>
+		<d2l-navigation-resolved
+			logo="[[logo]]"
+			items="[[items]]"></d2l-navigation-resolved>
 	</template>
-
 </dom-module>
-
 <script>
-
 	Polymer({
 		is: 'd2l-navigation',
 		properties: {
@@ -63,6 +42,7 @@
 				type: String
 			},
 			loading: {
+				reflectToAttribute: true,
 				type: Boolean,
 				value: false
 			},
@@ -103,11 +83,10 @@
 
 			var delay = Math.max(200, this.delay);
 			this.async(function() {
-				this.setAttribute('loaded', '');
 				this.$$('d2l-navigation-page-load-progress').finish();
 				this.fire('d2l-navigation-ready');
 				this.loading = false;
-			}.bind(this), delay)
+			}.bind(this), delay);
 
 		},
 		load: function() {
@@ -117,8 +96,6 @@
 			this.loading = true;
 			this.$$('iron-ajax').generateRequest();
 			this.$$('d2l-navigation-page-load-progress').start();
-			this.removeAttribute('loaded');
 		}
 	});
-
 </script>

--- a/navigation.html
+++ b/navigation.html
@@ -10,14 +10,14 @@
 	<style>
 		:host {
 			background-color: #fff;
-			border-bottom: 1px solid #e6eaf0;
 			display: block;
 			line-height: 1;
 			position: relative;
 		}
 		:host > nav {
+			border-bottom: 1px solid #e6eaf0;
 			opacity: 0;
-			transition: opacity 500ms;
+			transition: opacity 200ms;
 		}
 		:host[loaded] > nav {
 			opacity: 1;
@@ -101,10 +101,11 @@
 				src: logoSrc
 			};
 
-			var delay = Math.min(200, this.delay);
+			var delay = Math.max(200, this.delay);
 			this.async(function() {
 				this.setAttribute('loaded', '');
 				this.$$('d2l-navigation-page-load-progress').finish();
+				this.fire('d2l-navigation-ready');
 				this.loading = false;
 			}.bind(this), delay)
 

--- a/page-loading.html
+++ b/page-loading.html
@@ -1,0 +1,59 @@
+<style>
+body > * {
+	transition: opacity ease-in .2s;
+}
+
+body.d2l-page-loading > *:not(.d2l-page-loading-skip) {
+	opacity: 0;
+}
+</style>
+<script>
+(function() {
+	'use strict';
+
+	var pageReady, navReady = false;
+
+	function check() {
+		if (pageReady && navReady) {
+			document.body.classList.remove('d2l-page-loading');
+		}
+	}
+
+	function pageIsReady() {
+		if (pageReady) {
+			return;
+		}
+		document.body.addEventListener('d2l-navigation-ready', navIsReady);
+		var navs = document.getElementsByTagName('d2l-navigation');
+		if (navs.length === 0 || navs[0].hasAttribute('loaded')) {
+			navIsReady();
+		}
+		pageReady = true;
+		check();
+	}
+
+	function navIsReady() {
+		if (navReady) {
+			return;
+		}
+		navReady = true;
+		check();
+	}
+
+	if (window.WebComponents) {
+		addEventListener('WebComponentsReady', pageIsReady);
+	} else {
+		if (document.readyState === 'interactive' || document.readyState === 'complete') {
+			pageIsReady();
+		} else {
+			addEventListener('DOMContentLoaded', pageIsReady);
+		}
+	}
+
+	setTimeout(function() {
+		pageIsReady();
+		navIsReady();
+	}, 10000);
+
+})();
+</script>

--- a/page-loading.html
+++ b/page-loading.html
@@ -25,7 +25,7 @@ body.d2l-page-loading > *:not(.d2l-page-loading-skip) {
 		}
 		document.body.addEventListener('d2l-navigation-ready', navIsReady);
 		var navs = document.getElementsByTagName('d2l-navigation');
-		if (navs.length === 0 || navs[0].hasAttribute('loaded')) {
+		if (navs.length === 0 || !navs[0].hasAttribute('loading')) {
 			navIsReady();
 		}
 		pageReady = true;
@@ -33,9 +33,6 @@ body.d2l-page-loading > *:not(.d2l-page-loading-skip) {
 	}
 
 	function navIsReady() {
-		if (navReady) {
-			return;
-		}
 		navReady = true;
 		check();
 	}

--- a/samples/index.html
+++ b/samples/index.html
@@ -11,12 +11,12 @@
 		<link rel="stylesheet" href="sample.css">
 	</head>
 	<body class="d2l-page-loading">
-		<d2l-navigation endpoint="data/data1.json"></d2l-navigation>
+		<d2l-navigation endpoint="data/data1.json" class="d2l-page-loading-skip"></d2l-navigation>
 		<d2l-navigation-centerer>
 			<main>
 				<label>
 					Navigation delay (ms)<br />
-					<input type="text" id="delay" value="0" />
+					<input type="text" id="delay" value="200" />
 				</label>
 				<button id="apply">Apply</button>
 			</main>
@@ -25,6 +25,7 @@
 		document.getElementById('apply').addEventListener('click', function() {
 			var nav = document.querySelector('d2l-navigation');
 			nav.setAttribute('delay', parseInt(document.getElementById('delay').value));
+			document.body.classList.add('d2l-page-loading');
 			nav.load();
 		});
 		</script>

--- a/samples/index.html
+++ b/samples/index.html
@@ -7,9 +7,10 @@
 		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 		<link rel="import" href="../navigation.html">
 		<link rel="import" href="../centerer.html">
+		<link rel="import" href="../page-loading.html">
 		<link rel="stylesheet" href="sample.css">
 	</head>
-	<body unresolved>
+	<body class="d2l-page-loading">
 		<d2l-navigation endpoint="data/data1.json"></d2l-navigation>
 		<d2l-navigation-centerer>
 			<main>

--- a/test/index.html
+++ b/test/index.html
@@ -12,6 +12,7 @@
 			// Load and run all tests (.html, .js):
 			WCT.loadSuites([
 				'page-load-progress.html',
+				'page-load-progress.html?dom=shadow'
 			]);
 		</script>
 	</body>


### PR DESCRIPTION
This replaces Polymer's `unresolved` attribute that we've been placing on the `<body>` element (PRs in BSI and ILP coming). Instead, it hides all direct children of the body and waits for both the `WebComponentsReady` event AND the navigation to be ready.

You'll see checks to handle cases where:

1. WC polyfill is missing -> we just wait for `DOMContentLoaded` instead
2. There's no navigation on the page -> we proceed right away
3. Edge case where there is a nav on the page but things take longer than 10 seconds -> we assume something terrible happened and just show the rest of the page

I'm open to moving this into its own component in the future, but for now since it has so much knowledge of navigation I'd like to keep it hidden in here.

@dbatiste: what do you think?